### PR TITLE
update pydantic model attributes to snake_case

### DIFF
--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -39,13 +39,13 @@ class ScoreSet(DataSet):
     pubmed_identifiers: Optional[List[PubmedIdentifier]]
     target_gene: TargetGene
 
-    @validator('supersededScoresetUrn', 'metaAnalysisSourceScoresetUrns')
+    @validator('superseded_scoresetUrn', 'meta_analysis_source_scoreset_urns')
     def validate_scoreset_urn(cls, v):
         if type(v) == str:
             urn.validate_mavedb_urn_scoreset(v)
         else:
             [urn.validate_mavedb_urn_scoreset(s) for s in v]
 
-    @validator('experimentUrn')
+    @validator('experiment_urn')
     def validate_experiment_urn(cls, v):
         urn.validate_mavedb_urn_experiment(v)

--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -39,7 +39,7 @@ class ScoreSet(DataSet):
     pubmed_identifiers: Optional[List[PubmedIdentifier]]
     target_gene: TargetGene
 
-    @validator('superseded_scoresetUrn', 'meta_analysis_source_scoreset_urns')
+    @validator('superseded_scoreset_urn', 'meta_analysis_source_scoreset_urns')
     def validate_scoreset_urn(cls, v):
         if type(v) == str:
             urn.validate_mavedb_urn_scoreset(v)

--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -10,10 +10,10 @@ from mavecore.validation.utilities import to_camel
 
 class DataSet(BaseModel):
     title: str
-    shortDescription: str
-    abstractText: str
-    methodText: str
-    extraMetadata: Optional[Dict]
+    short_description: str
+    abstract_text: str
+    method_text: str
+    extra_metadata: Optional[Dict]
     keywords: Optional[List[str]]
 
     @validator('keywords')
@@ -22,19 +22,19 @@ class DataSet(BaseModel):
 
 
 class Experiment(DataSet):
-    doiIdentifiers: Optional[List[DoiIdentifier]]
-    pubmedIdentifiers: Optional[List[PubmedIdentifier]]
+    doi_identifiers: Optional[List[DoiIdentifier]]
+    pubmed_identifiers: Optional[List[PubmedIdentifier]]
 
 
 class ScoreSet(DataSet):
-    dataUsagePolicy: str
-    licenceId: int
-    experimentUrn: str
-    supersededScoresetUrn: Optional[str]
-    metaAnalysisSourceScoresetUrns: Optional[List[str]]
-    doiIdentifiers: Optional[List[DoiIdentifier]]
-    pubmedIdentifiers: Optional[List[PubmedIdentifier]]
-    targetGene: TargetGene
+    data_usage_policy: str
+    licence_id: int
+    experiment_urn: str
+    superseded_scoreset_urn: Optional[str]
+    meta_analysis_source_scoreset_urns: Optional[List[str]]
+    doi_identifiers: Optional[List[DoiIdentifier]]
+    pubmed_identifiers: Optional[List[PubmedIdentifier]]
+    target_gene: TargetGene
 
     @validator('supersededScoresetUrn', 'metaAnalysisSourceScoresetUrns')
     def validate_scoreset_urn(cls, v):

--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -5,6 +5,7 @@ from .identifier import DoiIdentifier, PubmedIdentifier
 from .target import TargetGene
 
 from mavecore.validation import keywords, urn
+from mavecore.validation.utilities import to_camel
 
 
 class DataSet(BaseModel):

--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -16,6 +16,9 @@ class DataSet(BaseModel):
     extra_metadata: Optional[Dict]
     keywords: Optional[List[str]]
 
+    class Config:
+        alias_generator = to_camel
+
     @validator('keywords')
     def validate_keywords(cls, v):
         keywords.validate_keywords(v)

--- a/mavecore/models/identifier.py
+++ b/mavecore/models/identifier.py
@@ -8,6 +8,9 @@ from mavecore.validation.utilities import to_camel
 class Identifier(BaseModel):
     identifier: str
 
+    class Config:
+        alias_generator = to_camel
+
 
 class DoiIdentifier(Identifier):
 

--- a/mavecore/models/identifier.py
+++ b/mavecore/models/identifier.py
@@ -53,6 +53,9 @@ class ExternalIdentifier(BaseModel):
     identifier: dict
     offset: Optional[int]
 
+    class Config:
+        alias_generator = to_camel
+
     @validator('identifier')
     def validate_identifier(cls, v):
         id.validate_external_identifier(v)

--- a/mavecore/models/identifier.py
+++ b/mavecore/models/identifier.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel, validator, root_validator
 from typing import Optional
 
 from mavecore.validation import identifier as id
+from mavecore.validation.utilities import to_camel
 
 
 class Identifier(BaseModel):

--- a/mavecore/models/map.py
+++ b/mavecore/models/map.py
@@ -4,5 +4,8 @@ from mavecore.validation.utilities import to_camel
 
 
 class ReferenceMap(BaseModel):
-    genomeId: int
-    targetId: int
+    genome_id: int
+    target_id: int
+
+    class Config:
+        alias_generator = to_camel

--- a/mavecore/models/map.py
+++ b/mavecore/models/map.py
@@ -1,5 +1,7 @@
 from pydantic import BaseModel
 
+from mavecore.validation.utilities import to_camel
+
 
 class ReferenceMap(BaseModel):
     genomeId: int

--- a/mavecore/models/sequence.py
+++ b/mavecore/models/sequence.py
@@ -8,7 +8,10 @@ class WildType(BaseModel):
     sequence_type: str
     sequence: str
 
-    @validator('sequenceType')
+    class Config:
+        alias_generator = to_camel
+
+    @validator('sequence_type')
     def validate_category(cls, v):
         target.validate_sequence_category(v)
 

--- a/mavecore/models/sequence.py
+++ b/mavecore/models/sequence.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, validator
 
 from mavecore.validation import target
+from mavecore.validation.utilities import to_camel
 
 
 class WildType(BaseModel):

--- a/mavecore/models/sequence.py
+++ b/mavecore/models/sequence.py
@@ -5,7 +5,7 @@ from mavecore.validation.utilities import to_camel
 
 
 class WildType(BaseModel):
-    sequenceType: str
+    sequence_type: str
     sequence: str
 
     @validator('sequenceType')

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -16,6 +16,9 @@ class TargetGene(BaseModel):
     reference_maps: List[ReferenceMap]
     wtSequence: WildType
 
+    class Config:
+        alias_generator = to_camel
+
     @validator('category')
     def validate_category(cls, v):
         target.validate_target_category(v)

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -12,8 +12,8 @@ from mavecore.validation.utilities import to_camel
 class TargetGene(BaseModel):
     name: str
     category: str
-    externalIdentifiers: List[ExternalIdentifier]
-    referenceMaps: List[ReferenceMap]
+    external_identifiers: List[ExternalIdentifier]
+    reference_maps: List[ReferenceMap]
     wtSequence: WildType
 
     @validator('category')

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -6,6 +6,7 @@ from .sequence import WildType
 
 from mavecore.validation import target
 from mavecore.models.identifier import ExternalIdentifier
+from mavecore.validation.utilities import to_camel
 
 
 class TargetGene(BaseModel):

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -14,7 +14,7 @@ class TargetGene(BaseModel):
     category: str
     external_identifiers: List[ExternalIdentifier]
     reference_maps: List[ReferenceMap]
-    wtSequence: WildType
+    wt_sequence: WildType
 
     class Config:
         alias_generator = to_camel

--- a/mavecore/validation/utilities.py
+++ b/mavecore/validation/utilities.py
@@ -8,6 +8,12 @@ from mavecore.validation.constants.conversion import aa_dict_key_1
 #from mavecore.validation.variant import validate_hgvs_string
 
 
+def to_camel(string: str) -> str:
+    camel = ''.join(word.capitalize() for word in string.split('_'))
+    camel = camel[0].lower() + camel[1:]
+    return camel
+
+
 def is_null(value):
     """
     Returns True if a stripped/lowercase value in in `nan_col_values`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pre-commit
 coverage
+pydantic


### PR DESCRIPTION
Updates pydantic model attributes to snake_case and handles instances of camelCase via alias generators, info on alias generators here: https://pydantic-docs.helpmanual.io/usage/model_config/ .