### PR TITLE
allow models to populate by field name

### DIFF
--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -23,6 +23,7 @@ class DataSet(BaseModel):
     @validator('keywords')
     def validate_keywords(cls, v):
         keywords.validate_keywords(v)
+        return v
 
 
 class Experiment(DataSet):
@@ -46,7 +47,9 @@ class ScoreSet(DataSet):
             urn.validate_mavedb_urn_scoreset(v)
         else:
             [urn.validate_mavedb_urn_scoreset(s) for s in v]
+        return v
 
     @validator('experiment_urn')
     def validate_experiment_urn(cls, v):
         urn.validate_mavedb_urn_experiment(v)
+        return v

--- a/mavecore/models/data.py
+++ b/mavecore/models/data.py
@@ -18,6 +18,7 @@ class DataSet(BaseModel):
 
     class Config:
         alias_generator = to_camel
+        allow_population_by_field_name = True
 
     @validator('keywords')
     def validate_keywords(cls, v):

--- a/mavecore/models/identifier.py
+++ b/mavecore/models/identifier.py
@@ -10,6 +10,7 @@ class Identifier(BaseModel):
 
     class Config:
         alias_generator = to_camel
+        allow_population_by_field_name = True
 
 
 class DoiIdentifier(Identifier):

--- a/mavecore/models/identifier.py
+++ b/mavecore/models/identifier.py
@@ -18,6 +18,7 @@ class DoiIdentifier(Identifier):
     @validator('identifier')
     def must_be_valid_doi(cls, v):
         id.validate_doi_identifier(v)
+        return v
 
 
 class PubmedIdentifier(Identifier):
@@ -25,6 +26,7 @@ class PubmedIdentifier(Identifier):
     @validator('identifier')
     def must_be_valid_pubmed(cls, v):
         id.validate_pubmed_identifier(v)
+        return v
 
 
 '''class ExternalIdentifierId(BaseModel):
@@ -63,3 +65,4 @@ class ExternalIdentifier(BaseModel):
     @validator('identifier')
     def validate_identifier(cls, v):
         id.validate_external_identifier(v)
+        return v

--- a/mavecore/models/map.py
+++ b/mavecore/models/map.py
@@ -9,3 +9,4 @@ class ReferenceMap(BaseModel):
 
     class Config:
         alias_generator = to_camel
+        allow_population_by_field_name = True

--- a/mavecore/models/sequence.py
+++ b/mavecore/models/sequence.py
@@ -10,6 +10,7 @@ class WildType(BaseModel):
 
     class Config:
         alias_generator = to_camel
+        allow_population_by_field_name = True
 
     @validator('sequence_type')
     def validate_category(cls, v):

--- a/mavecore/models/sequence.py
+++ b/mavecore/models/sequence.py
@@ -15,7 +15,9 @@ class WildType(BaseModel):
     @validator('sequence_type')
     def validate_category(cls, v):
         target.validate_sequence_category(v)
+        return v
 
     @validator('sequence')
     def validate_sequence(cls, v):
         target.validate_target_sequence(v)
+        return v

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -23,3 +23,4 @@ class TargetGene(BaseModel):
     @validator('category')
     def validate_category(cls, v):
         target.validate_target_category(v)
+        return v

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -18,6 +18,7 @@ class TargetGene(BaseModel):
 
     class Config:
         alias_generator = to_camel
+        allow_population_by_field_name = True
 
     @validator('category')
     def validate_category(cls, v):

--- a/mavecore/models/target.py
+++ b/mavecore/models/target.py
@@ -12,8 +12,8 @@ from mavecore.validation.utilities import to_camel
 class TargetGene(BaseModel):
     name: str
     category: str
-    external_identifiers: List[ExternalIdentifier]
-    reference_maps: List[ReferenceMap]
+    external_identifiers: Optional[List[ExternalIdentifier]]
+    reference_maps: Optional[List[ReferenceMap]]
     wt_sequence: WildType
 
     class Config:

--- a/mavecore/validation/dataset.py
+++ b/mavecore/validation/dataset.py
@@ -21,7 +21,7 @@ def validate_experiment(experiment: dict):
         If required keys are missing or any keys contain incorrect values.
     """
     try:
-        return json.loads(Experiment.parse_obj(experiment).json())
+        return Experiment.parse_obj(experiment).dict(by_alias=True, exclude_none=True)
     except ValueError as e:
         raise ValidationError(e)
 
@@ -44,6 +44,7 @@ def validate_scoreset(scoreset: dict):
         If required keys are missing or any keys contain incorrect values.
     """
     try:
-        return json.loads(ScoreSet.parse_obj(scoreset).json())
+        #return json.loads(ScoreSet.parse_obj(scoreset).json())
+        return ScoreSet.parse_obj(scoreset).dict(by_alias=True, exclude_none=True)
     except ValueError as e:
         raise ValidationError(e)

--- a/mavecore/validation/dataset.py
+++ b/mavecore/validation/dataset.py
@@ -1,6 +1,7 @@
 import json
 
 from mavecore.models.data import Experiment, ScoreSet
+from mavecore.validation.exceptions import ValidationError
 
 
 def validate_experiment(experiment: dict):
@@ -22,7 +23,7 @@ def validate_experiment(experiment: dict):
     try:
         return json.loads(Experiment.parse_obj(experiment).json())
     except ValueError as e:
-        print(e)
+        raise ValidationError(e)
 
 
 def validate_scoreset(scoreset: dict):
@@ -45,4 +46,4 @@ def validate_scoreset(scoreset: dict):
     try:
         return json.loads(ScoreSet.parse_obj(scoreset).json())
     except ValueError as e:
-        print(e)
+        raise ValidationError(e)

--- a/mavecore/validation/identifier.py
+++ b/mavecore/validation/identifier.py
@@ -34,11 +34,9 @@ def validate_external_identifier(identifier: dict):
 
     # check that the keys are the right name
     if "dbname" not in identifier:
-        raise ValidationError("The identifier attribute of the external identifier should have two Keys, `dbname` "
-                              "and `identifier`.")
+        raise ValidationError("The identifier attribute of the external identifier should have the key `dbname`.")
     if "identifier" not in identifier:
-        raise ValidationError("The identifier attribute of the external identifier should have two Keys, `dbname` "
-                              "and `identifier`.")
+        raise ValidationError("The identifier attribute of the external identifier should have the key `identifier`.")
 
     # check that dbname is valid
     if identifier.get("dbname") not in valid_dbnames:

--- a/mavecore/validation/identifier.py
+++ b/mavecore/validation/identifier.py
@@ -33,22 +33,28 @@ def validate_external_identifier(identifier: dict):
                               "and `identifier`.")
 
     # check that the keys are the right name
-    if "dbname" not in identifier:
-        raise ValidationError("The identifier attribute of the external identifier should have the key `dbname`.")
+    if "dbName" or "db_name" not in identifier:
+        raise ValidationError("The identifier attribute of the external identifier should have the key `dbName` or 'db_name`.")
     if "identifier" not in identifier:
         raise ValidationError("The identifier attribute of the external identifier should have the key `identifier`.")
 
+    # assign dbName key to variable
+    if "dbName" in identifier:
+        db_name = "dbName"
+    else:
+        db_name = "db_name"
+
     # check that dbname is valid
-    if identifier.get("dbname") not in valid_dbnames:
-        raise ValidationError(f"The `dbname` key within the identifier attribute of the external identifier should "
+    if identifier.get(db_name) not in valid_dbnames:
+        raise ValidationError(f"The `db_name` key within the identifier attribute of the external identifier should "
                               f"take one of the following values: {valid_dbnames}.")
 
     # validate identifier based on dbname: could be one of UniProt, RefSeq, or Ensembl
-    if identifier.get("dbname") == "UniProt":
+    if identifier.get(db_name) == "UniProt":
         validate_uniprot_identifier(identifier.get("identifier"))
-    elif identifier.get("dbname") == "RefSeq":
+    elif identifier.get(db_name) == "RefSeq":
         validate_refseq_identifier(identifier.get("identifier"))
-    elif identifier.get("dbname") == "Ensembl":
+    elif identifier.get(db_name) == "Ensembl":
         validate_ensembl_identifier(identifier.get("identifier"))
 
 

--- a/mavecore/validation/identifier.py
+++ b/mavecore/validation/identifier.py
@@ -33,7 +33,7 @@ def validate_external_identifier(identifier: dict):
                               "and `identifier`.")
 
     # check that the keys are the right name
-    if "dbName" or "db_name" not in identifier:
+    if "db_name" not in identifier and "dbName" not in identifier:
         raise ValidationError("The identifier attribute of the external identifier should have the key `dbName` or 'db_name`.")
     if "identifier" not in identifier:
         raise ValidationError("The identifier attribute of the external identifier should have the key `identifier`.")

--- a/tests/models/data.py
+++ b/tests/models/data.py
@@ -7,10 +7,10 @@ class TestDataSet(TestCase):
     def setUp(self):
         self.dataset = {
             "title": "title",
-            "shortDescription": "short description",
-            "abstractText": "abstract",
-            "methodText": "methods",
-            "extraMetadata": {},
+            "short_description": "short description",
+            "abstract_text": "abstract",
+            "method_text": "methods",
+            "extra_metadata": {},
             "keywords": ["string"],
         }
 
@@ -18,7 +18,7 @@ class TestDataSet(TestCase):
         DataSet.parse_obj(self.dataset)
 
     def test_valid_exclude_optional(self):
-        self.dataset.pop("extraMetadata")
+        self.dataset.pop("extra_metadata")
         self.dataset.pop("keywords")
         DataSet.parse_obj(self.dataset)
 
@@ -34,23 +34,23 @@ class TestExperiment(TestCase):
         pubmed_identifier = {"identifier": "29785012"}
         self.experiment = {
             "title": "title",
-            "shortDescription": "short description",
-            "abstractText": "abstract",
-            "methodText": "methods",
-            "extraMetadata": {},
+            "short_description": "short description",
+            "abstract_text": "abstract",
+            "method_text": "methods",
+            "extra_metadata": {},
             "keywords": ["string"],
-            "doiIdentifiers": [doi_identifier],
-            "pubmedIdentifiers": [pubmed_identifier],
+            "doi_identifiers": [doi_identifier],
+            "pubmed_identifiers": [pubmed_identifier],
         }
 
     def test_valid_all_fields(self):
         Experiment.parse_obj(self.experiment)
 
     def test_valid_exclude_optional(self):
-        self.experiment.pop("extraMetadata")
+        self.experiment.pop("extra_metadata")
         self.experiment.pop("keywords")
-        self.experiment.pop("doiIdentifiers")
-        self.experiment.pop("pubmedIdentifiers")
+        self.experiment.pop("doi_identifiers")
+        self.experiment.pop("pubmed_identifiers")
         Experiment.parse_obj(self.experiment)
 
 

--- a/tests/models/map.py
+++ b/tests/models/map.py
@@ -5,8 +5,8 @@ from mavecore.models.map import ReferenceMap
 class TestReferenceMap(TestCase):
     def setUp(self):
         self.reference_map = {
-            "genomeId": 0,
-            "targetId": 0,
+            "genome_id": 0,
+            "target_id": 0,
         }
 
     def test_valid_all_fields(self):

--- a/tests/models/sequence.py
+++ b/tests/models/sequence.py
@@ -6,14 +6,14 @@ from mavecore.models.sequence import WildType
 class Test(TestCase):
     def test_valid_all_fields(self):
         sequence = {
-            "sequenceType": "Protein",
+            "sequence_type": "Protein",
             "sequence": "ATC",
         }
         WildType.parse_obj(sequence)
 
     def test_invalid_sequence_type(self):
         sequence = {
-            "sequenceType": "RNA",
+            "sequence_type": "RNA",
             "sequence": "ATC",
         }
         with self.assertRaises(ValidationError):

--- a/tests/validation/dataset.py
+++ b/tests/validation/dataset.py
@@ -8,13 +8,13 @@ class TestValidateExperiment(TestCase):
         pubmed_identifier = {"identifier": "29785012"}
         self.experiment = {
             "title": "title",
-            "shortDescription": "short description",
-            "abstractText": "abstract",
-            "methodText": "methods",
-            "extraMetadata": {},
+            "short_description": "short description",
+            "abstract_text": "abstract",
+            "method_text": "methods",
+            "extra_metadata": {},
             "keywords": ["string"],
-            "doiIdentifiers": [doi_identifier],
-            "pubmedIdentifiers": [pubmed_identifier],
+            "doi_identifiers": [doi_identifier],
+            "pubmed_identifiers": [pubmed_identifier],
         }
 
     def test_valid_all_fields(self):
@@ -29,10 +29,10 @@ class TestValidateExperiment(TestCase):
             print(e)'''
 
     def test_valid_exclude_optional(self):
-        self.experiment.pop("extraMetadata")
+        self.experiment.pop("extra_metadata")
         self.experiment.pop("keywords")
-        self.experiment.pop("doiIdentifiers")
-        self.experiment.pop("pubmedIdentifiers")
+        self.experiment.pop("doi_identifiers")
+        self.experiment.pop("pubmed_identifiers")
         validate_experiment(self.experiment)
 
 
@@ -40,40 +40,40 @@ class TestValidateScoreSet(TestCase):
     def setUp(self):
         doi_identifier = {"identifier": "10.1038/s41588-018-0122-z"}
         pubmed_identifier = {"identifier": "29785012"}
-        reference_map = {"genomeId": 0, "targetId": 0}
-        sequence = {"sequenceType": "DNA", "sequence": "ATC"}
+        reference_map = {"genome_id": 0, "target_id": 0}
+        sequence = {"sequence_type": "DNA", "sequence": "ATC"}
         external_identifier_id = {"dbname": "UniProt", "identifier": "P01133"}
         external_identifier = {"identifier": external_identifier_id, "offset": 0}
         target = {"name": "name",
                   "category": "Protein coding",
-                  "externalIdentifiers": [external_identifier],
-                  "referenceMaps": [reference_map],
-                  "wtSequence": sequence}
+                  "external_identifiers": [external_identifier],
+                  "reference_maps": [reference_map],
+                  "wt_sequence": sequence}
         self.scoreset = {
             "title": "title",
-            "shortDescription": "short description",
-            "abstractText": "abstract",
-            "methodText": "methods",
-            "extraMetadata": {},
-            "dataUsagePolicy": "policy",
-            "licenceId": 0,
+            "short_description": "short description",
+            "abstract_text": "abstract",
+            "method_text": "methods",
+            "extra_metadata": {},
+            "dataUsage_policy": "policy",
+            "licence_id": 0,
             "keywords": ["string"],
-            "experimentUrn": "tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5",
-            "supersededScoresetUrn": "tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5",
-            "metaAnalysisSourceScoresetUrns": ["tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5"],
-            "doiIdentifiers": [doi_identifier],
-            "pubmedIdentifiers": [pubmed_identifier],
-            "targetGene": target,
+            "experiment_urn": "tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5",
+            "superseded_scoreset_urn": "tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5",
+            "meta_analysis_source_scoreset_urns": ["tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5"],
+            "doi_identifiers": [doi_identifier],
+            "pubmed_identifiers": [pubmed_identifier],
+            "target_gene": target,
         }
 
     def test_valid_all_fields(self):
         validate_scoreset(self.scoreset)
 
     def test_valid_exclude_optional(self):
-        self.scoreset.pop("extraMetadata")
+        self.scoreset.pop("extra_metadata")
         self.scoreset.pop("keywords")
-        self.scoreset.pop("doiIdentifiers")
-        self.scoreset.pop("pubmedIdentifiers")
-        self.scoreset.pop("supersededScoresetUrn")
-        self.scoreset.pop("metaAnalysisSourceScoresetUrns")
+        self.scoreset.pop("doi_identifiers")
+        self.scoreset.pop("pubmed_identifiers")
+        self.scoreset.pop("superseded_scoreset_urn")
+        self.scoreset.pop("meta_analysis_source_scoreset_urns")
         validate_scoreset(self.scoreset)

--- a/tests/validation/dataset.py
+++ b/tests/validation/dataset.py
@@ -42,7 +42,7 @@ class TestValidateScoreSet(TestCase):
         pubmed_identifier = {"identifier": "29785012"}
         reference_map = {"genome_id": 0, "target_id": 0}
         sequence = {"sequence_type": "DNA", "sequence": "ATC"}
-        external_identifier_id = {"dbname": "UniProt", "identifier": "P01133"}
+        external_identifier_id = {"db_name": "UniProt", "identifier": "P01133"}
         external_identifier = {"identifier": external_identifier_id, "offset": 0}
         target = {"name": "name",
                   "category": "Protein coding",

--- a/tests/validation/dataset.py
+++ b/tests/validation/dataset.py
@@ -55,7 +55,7 @@ class TestValidateScoreSet(TestCase):
             "abstract_text": "abstract",
             "method_text": "methods",
             "extra_metadata": {},
-            "dataUsage_policy": "policy",
+            "data_usage_policy": "policy",
             "licence_id": 0,
             "keywords": ["string"],
             "experiment_urn": "tmp:0a56b8eb-8e19-4906-8cc7-d17d884330a5",


### PR DESCRIPTION
Update model configuration to allow models to be populated by both alias name and field name. Make sure unit testing demonstates this functionality.